### PR TITLE
Feature: Added support for CMS landing pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,21 @@
 CHANGELOG for Shopware PWA
 ===================
 
+### 0.3.1
+
+> CMS landing pages are now supported
+
+**Added**
+* Constant `LANDING_PAGE_ROUTE` in `SwagShopwarePwa\Pwa\Controller\PageController`
+* Class `SwagShopwarePwa\Pwa\PageLoader\LandingPageLoader`
+* Class `SwagShopwarePwa\Pwa\PageResult\Landing\LandingPageResult`
+* Class `SwagShopwarePwa\Pwa\PageResult\Landing\LandingPageResultHydrator`
+* PHPUnit test groups
+    * `pwa-page-product`
+    * `pwa-page-category`
+    * `pwa-page-landing`
+    * `pwa-page-routing` 
+
 ### 0.3.0
 
 > PHP level has been increased to PHP 7.4

--- a/src/Pwa/Controller/PageController.php
+++ b/src/Pwa/Controller/PageController.php
@@ -29,6 +29,8 @@ class PageController extends AbstractController
 
     const NAVIGATION_PAGE_ROUTE = 'frontend.navigation.page';
 
+    const LANDING_PAGE_ROUTE = 'frontend.landing.page';
+
     /**
      * @var PageLoaderContextBuilderInterface
      */
@@ -79,7 +81,7 @@ class PageController extends AbstractController
      *                          property="resourceType",
      *                          description="Type of page that was fetched. Indicates whether it is a product page or a category page",
      *                          type="string",
-     *                          enum={"frontend.detail.page", "frontend.navigation.page"}
+     *                          enum={"frontend.detail.page", "frontend.navigation.page", "frontend.landing.page"}
      *                      ),
      *                      @OA\Property(
      *                          property="resourceIdentifier",
@@ -136,6 +138,9 @@ Each element has the category identifier as its key and contains a `path` as wel
      *                                  description="The category associated with the loaded page.",
      *                                  ref="#/components/schemas/category_flat"
      *                              )
+     *                          ),
+     *                          @OA\Schema(
+     *                              description="A landing page result contains no specific fields."
      *                          )
      *                      }
      *                  )
@@ -190,7 +195,6 @@ Each element has the category identifier as its key and contains a `path` as wel
      */
     private function getPageResult(PageLoaderInterface $pageLoader, PageLoaderContext $pageLoaderContext): AbstractPageResult
     {
-
         /** @var AbstractPageResult $pageResult */
         $pageResult = $pageLoader->load($pageLoaderContext);
 

--- a/src/Pwa/PageLoader/Context/PathResolver.php
+++ b/src/Pwa/PageLoader/Context/PathResolver.php
@@ -17,7 +17,8 @@ class PathResolver implements PathResolverInterface
 {
     private const MATCH_MAP = [
         PageController::NAVIGATION_PAGE_ROUTE => '/^\/?navigation\/([a-f0-9]{32})$/',
-        PageController::PRODUCT_PAGE_ROUTE => '/^\/?detail\/([a-f0-9]{32})$/'
+        PageController::PRODUCT_PAGE_ROUTE => '/^\/?detail\/([a-f0-9]{32})$/',
+        PageController::LANDING_PAGE_ROUTE => '/^\/?landingPage\/([a-f0-9]{32})$/'
     ];
 
     private const ROOT_ROUTE_NAME = PageController::NAVIGATION_PAGE_ROUTE;

--- a/src/Pwa/PageLoader/LandingPageLoader.php
+++ b/src/Pwa/PageLoader/LandingPageLoader.php
@@ -1,0 +1,61 @@
+<?php declare(strict_types=1);
+
+namespace SwagShopwarePwa\Pwa\PageLoader;
+
+use Shopware\Core\Content\LandingPage\SalesChannel\AbstractLandingPageRoute;
+use Shopware\Core\Content\LandingPage\SalesChannel\LandingPageRoute;
+use SwagShopwarePwa\Pwa\PageLoader\Context\PageLoaderContext;
+use SwagShopwarePwa\Pwa\PageResult\Landing\LandingPageResult;
+use SwagShopwarePwa\Pwa\PageResult\Landing\LandingPageResultHydrator;
+
+/**
+ * This class loads a static landing page. Landing pages behave the same way as CMS pages, but do not have a breadcrumb.
+ *
+ * @package SwagShopwarePwa\Pwa\PageLoader
+ */
+class LandingPageLoader implements PageLoaderInterface
+{
+    private const RESOURCE_TYPE = 'frontend.landing.page';
+
+    /**
+     * @var LandingPageRoute
+     */
+    private $landingPageRoute;
+
+    /**
+     * @var LandingPageResultHydrator
+     */
+    private $resultHydrator;
+
+    public function __construct(AbstractLandingPageRoute $landingPageRoute, LandingPageResultHydrator $resultHydrator)
+    {
+        $this->landingPageRoute = $landingPageRoute;
+        $this->resultHydrator = $resultHydrator;
+    }
+
+    public function getResourceType(): string
+    {
+        return self::RESOURCE_TYPE;
+    }
+
+    /**
+     * @param PageLoaderContext $pageLoaderContext
+     *
+     * @return LandingPageResult
+     */
+    public function load(PageLoaderContext $pageLoaderContext): LandingPageResult
+    {
+        $landingPageResult = $this->landingPageRoute->load(
+            $pageLoaderContext->getResourceIdentifier(),
+            $pageLoaderContext->getRequest(),
+            $pageLoaderContext->getContext()
+        );
+
+        $pageResult = $this->resultHydrator->hydrate(
+            $pageLoaderContext,
+            $landingPageResult->getLandingPage()->getCmsPage() ?? null
+        );
+
+        return $pageResult;
+    }
+}

--- a/src/Pwa/PageLoader/ProductPageLoader.php
+++ b/src/Pwa/PageLoader/ProductPageLoader.php
@@ -4,13 +4,9 @@ namespace SwagShopwarePwa\Pwa\PageLoader;
 
 use Shopware\Core\Content\Product\Exception\ProductNumberNotFoundException;
 use Shopware\Core\Content\Product\SalesChannel\Detail\AbstractProductDetailRoute;
-use Shopware\Core\Content\Product\SalesChannel\ProductAvailableFilter;
 use Shopware\Core\Content\Product\SalesChannel\SalesChannelProductDefinition;
-use Shopware\Core\Content\Product\SalesChannel\SalesChannelProductEntity;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
-use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\RequestCriteriaBuilder;
-use Shopware\Core\System\SalesChannel\Entity\SalesChannelRepositoryInterface;
 use SwagShopwarePwa\Pwa\PageLoader\Context\PageLoaderContext;
 use SwagShopwarePwa\Pwa\PageResult\Product\ProductPageResult;
 use SwagShopwarePwa\Pwa\PageResult\Product\ProductPageResultHydrator;
@@ -78,11 +74,6 @@ class ProductPageLoader implements PageLoaderInterface
             $criteria,
             $this->productDefinition,
             $pageLoaderContext->getContext()->getContext()
-        );
-
-        $criteria->addFilter(
-            new ProductAvailableFilter($pageLoaderContext->getContext()->getSalesChannel()->getId()),
-            new EqualsFilter('active', 1)
         );
 
         $result = $this->productRoute->load(

--- a/src/Pwa/PageResult/Landing/LandingPageResult.php
+++ b/src/Pwa/PageResult/Landing/LandingPageResult.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+namespace SwagShopwarePwa\Pwa\PageResult\Landing;
+
+use Shopware\Core\Content\Category\CategoryEntity;
+use Shopware\Core\Content\Cms\CmsPageEntity;
+use SwagShopwarePwa\Pwa\PageResult\AbstractPageResult;
+
+class LandingPageResult extends AbstractPageResult
+{
+}

--- a/src/Pwa/PageResult/Landing/LandingPageResultHydrator.php
+++ b/src/Pwa/PageResult/Landing/LandingPageResultHydrator.php
@@ -1,0 +1,22 @@
+<?php declare(strict_types=1);
+
+namespace SwagShopwarePwa\Pwa\PageResult\Landing;
+
+use Shopware\Core\Content\Category\CategoryEntity;
+use Shopware\Core\Content\Cms\CmsPageEntity;
+use SwagShopwarePwa\Pwa\PageLoader\Context\PageLoaderContext;
+use SwagShopwarePwa\Pwa\PageResult\AbstractPageResultHydrator;
+
+class LandingPageResultHydrator extends AbstractPageResultHydrator
+{
+    public function hydrate(PageLoaderContext $pageLoaderContext, ?CmsPageEntity $cmsPageEntity): LandingPageResult
+    {
+        $pageResult = new LandingPageResult();
+
+        $pageResult->setCmsPage($cmsPageEntity);
+        $pageResult->setResourceType($pageLoaderContext->getResourceType());
+        $pageResult->setResourceIdentifier($pageLoaderContext->getResourceIdentifier());
+
+        return $pageResult;
+    }
+}

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -54,6 +54,12 @@
             <tag name="pwa.page_loader"/>
         </service>
 
+        <service id="SwagShopwarePwa\Pwa\PageLoader\LandingPageLoader">
+            <argument type="service" id="Shopware\Core\Content\LandingPage\SalesChannel\LandingPageRoute" />
+            <argument type="service" id="SwagShopwarePwa\Pwa\PageResult\Landing\LandingPageResultHydrator" />
+            <tag name="pwa.page_loader"/>
+        </service>
+
 
         <!-- Page hydrators -->
 
@@ -67,6 +73,9 @@
                  parent="SwagShopwarePwa\Pwa\PageResult\AbstractPageResultHydrator"/>
 
         <service id="SwagShopwarePwa\Pwa\PageResult\Navigation\NavigationPageResultHydrator"
+                 parent="SwagShopwarePwa\Pwa\PageResult\AbstractPageResultHydrator"/>
+
+        <service id="SwagShopwarePwa\Pwa\PageResult\Landing\LandingPageResultHydrator"
                  parent="SwagShopwarePwa\Pwa\PageResult\AbstractPageResultHydrator"/>
 
 


### PR DESCRIPTION
This PR adds a new page type `frontend.landing.page` to the page resolver mechanism.

A typical result looks like this:

```json
{
  "resourceType": "frontend.landing.page",
  "resourceIdentifier": "08dea8c4e8f941a7aa6e61a4e03eda65",
  "canonicalPathInfo": "\/landing-foo-page",
  "cmsPage": {
    "name": "My Landing Page",
    "type": "landingpage",
    "entity": null,
    "sections": [],
    "apiAlias": "cms_page"
  },
  "breadcrumb": null,
  "apiAlias": "pwa_page_result"
}
```

Background: With Shopware 6.4 we've added landing pages as a feature to provide pages with a static URL, that are not part of the category tree, but still accessible. These pages don't have category-specific features like configuration mapping, but can contain any type of blocks and content. Landing pages **do not have breadcrumbs**, as they are not part of the category tree, but can have additional meta-information, such as _title_, _description_ or _keyword_ attached.

![image](https://user-images.githubusercontent.com/7780750/123986374-8a2eb180-d9c6-11eb-9169-bd3c150e3965.png)
