### PR TITLE
Added missing return to DumpPluginConfigurationCommand

### DIFF
--- a/src/Pwa/Bundle/Command/DumpPluginConfigurationCommand.php
+++ b/src/Pwa/Bundle/Command/DumpPluginConfigurationCommand.php
@@ -49,5 +49,7 @@ class DumpPluginConfigurationCommand extends Command
         $io->text('Assets');
         $assetArtifact = $this->assetService->dumpBundles();
         $io->comment('Wrote assets to \'' . $assetArtifact . '\'');
+
+        return self::SUCCESS;
     }
 }


### PR DESCRIPTION
If you try to call `bin/console pwa:dump-plugins`
you will get the error:
```
In Command.php line 259:
                                                                                                                                            
  Return value of "SwagShopwarePwa\Pwa\Bundle\Command\DumpPluginConfigurationCommand::execute()" must be of the type int, "null" returned.  
```

I fixed this
                                                                                                                                          