### PR TITLE
setDescription causes segfault when running bin/console

### DIFF
--- a/src/Pwa/Bundle/Command/DumpPluginConfigurationCommand.php
+++ b/src/Pwa/Bundle/Command/DumpPluginConfigurationCommand.php
@@ -12,6 +12,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 class DumpPluginConfigurationCommand extends Command
 {
     protected static $defaultName = 'pwa:dump-plugins';
+    protected static $defaultDescription = 'Dump PWA plugin configurations and assets';
 
     /**
      * @var ConfigurationService
@@ -29,11 +30,6 @@ class DumpPluginConfigurationCommand extends Command
         $this->assetService = $assetService;
 
         parent::__construct();
-    }
-
-    public function setDescription($description)
-    {
-        $this->setDescription('Dump PWA plugin configurations and assets');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output)


### PR DESCRIPTION
This has probably never been ran, and therefore not been an issue earlier, but as Shopware 6.4.3.x has a dependency on symfony/console ~5.3.0, and symfony/console 5.3.0 and onwards runs setDescription in the constructor, things go boom.